### PR TITLE
Option to input or output HAND as xarray

### DIFF
--- a/src/hydrosar/hand/prepare.py
+++ b/src/hydrosar/hand/prepare.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Union
+from typing import Union, Optional
 
 import xarray as xr
 from asf_tools import vector
@@ -52,7 +52,8 @@ def prepare_hand_vrt(vrt: Union[str, Path], geometry: Union[ogr.Geometry, BaseGe
 
 
 def prepare_hand_for_raster(
-    hand_raster: Union[str, Path], source_raster: Union[str, Path], resampling_method: str = 'lanczos'
+    source_raster: Union[str, Path, xr.DataArray], hand_raster: Optional[Union[str, Path]] = None,
+    return_xarray: bool = True, resampling_method: str = 'lanczos'
 ):
     """Create a HAND raster pixel-aligned to a source raster
 
@@ -62,6 +63,8 @@ def prepare_hand_for_raster(
         resampling_method: Name of the resampling method to use. For available methods, see:
             https://gdal.org/programs/gdalwarp.html#cmdoption-gdalwarp-r
     """
+    if hand_raster is None and not return_xarray:
+        raise ValueError("At least one output must be requested: set hand_raster to a path and/or return_xarray=True.")
 
     if isinstance(source_raster, xr.core.dataarray.DataArray):
         geobox = source_raster.odc.geobox.extent.to_crs('EPSG:4326')
@@ -88,8 +91,13 @@ def prepare_hand_for_raster(
 
     with NamedTemporaryFile(suffix='.vrt', delete=False) as hand_vrt:
         prepare_hand_vrt(hand_vrt.name, hand_geometry)
+        # Choose output target
+        if hand_raster is None:
+            out_path = '/vsimem/hand_aligned.tif'
+        else:
+            out_path = str(hand_raster)
         gdal.Warp(
-            str(hand_raster),
+            out_path,
             hand_vrt.name,
             dstSRS=f'EPSG:{epsg}',
             outputBounds=hand_bounds,
@@ -97,3 +105,20 @@ def prepare_hand_for_raster(
             height=height,
             resampleAlg=Resampling[resampling_method].value,
         )
+
+    if not return_xarray:
+        return None
+
+    ds = gdal.Open(out_path)
+    band = ds.GetRasterBand(1)
+    hand_array = band.ReadAsArray()
+    ds = None
+
+    # Clean up /vsimem output if used
+    if hand_raster is None:
+        try:
+            gdal.Unlink(out_path)
+        except Exception:
+            pass
+
+    return xr.DataArray(hand_array, dims=('y', 'x'))

--- a/src/hydrosar/hand/prepare.py
+++ b/src/hydrosar/hand/prepare.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Union, Optional
+from typing import Optional, Union
 
 import xarray as xr
 from asf_tools import vector
@@ -52,8 +52,10 @@ def prepare_hand_vrt(vrt: Union[str, Path], geometry: Union[ogr.Geometry, BaseGe
 
 
 def prepare_hand_for_raster(
-    source_raster: Union[str, Path, xr.DataArray], hand_raster: Optional[Union[str, Path]] = None,
-    return_xarray: bool = True, resampling_method: str = 'lanczos'
+    source_raster: Union[str, Path, xr.DataArray],
+    hand_raster: Optional[Union[str, Path]] = None,
+    return_xarray: bool = True,
+    resampling_method: str = 'lanczos',
 ):
     """Create a HAND raster pixel-aligned to a source raster
 
@@ -64,7 +66,7 @@ def prepare_hand_for_raster(
             https://gdal.org/programs/gdalwarp.html#cmdoption-gdalwarp-r
     """
     if hand_raster is None and not return_xarray:
-        raise ValueError("At least one output must be requested: set hand_raster to a path and/or return_xarray=True.")
+        raise ValueError('At least one output must be requested: set hand_raster to a path and/or return_xarray=True.')
 
     if isinstance(source_raster, xr.core.dataarray.DataArray):
         geobox = source_raster.odc.geobox.extent.to_crs('EPSG:4326')

--- a/src/hydrosar/water_map.py
+++ b/src/hydrosar/water_map.py
@@ -268,19 +268,19 @@ def make_water_map(
 
     # Warn if user asked to write HAND but also supplied one
     if hand_out and hand_raster is not None:
-        log.warning("hand_out=True ignored because hand_raster was provided.")
+        log.warning('hand_out=True ignored because hand_raster was provided.')
 
     if isinstance(hand_raster, xr.DataArray):
         hand_array = hand_raster.to_masked_array()
-        hand_source = "provided xarray"
+        hand_source = 'provided xarray'
 
     elif isinstance(hand_raster, (str, Path)):
         hand_array = read_as_masked_array(hand_raster)
-        hand_source = f"provided raster: {hand_raster}"
+        hand_source = f'provided raster: {hand_raster}'
 
     else:
         if hand_out:
-            out_path = str(Path(out_raster).with_suffix("")) + "_HAND.tif"
+            out_path = str(Path(out_raster).with_suffix('')) + '_HAND.tif'
             log.info(f'Extracting HAND data to: {out_path}')
 
         hand_xr = prepare_hand_for_raster(
@@ -289,7 +289,7 @@ def make_water_map(
             return_xarray=True,
         )
         hand_array = hand_xr.to_masked_array()
-        hand_source = "computed xarray"
+        hand_source = 'computed xarray'
 
     if out_path is not None:
         log.info(f'Determining HAND memberships from {hand_source}, which is also written out to {out_path}')

--- a/src/hydrosar/water_map.py
+++ b/src/hydrosar/water_map.py
@@ -185,9 +185,10 @@ def fuzzy_refinement(
 
 def make_water_map(
     out_raster: Union[str, Path],
-    vv_raster: Union[str, Path, xr.core.dataarray.DataArray],
-    vh_raster: Union[str, Path, xr.core.dataarray.DataArray],
-    hand_raster: Optional[Union[str, Path]] = None,
+    vv_raster: Union[str, Path, xr.DataArray],
+    vh_raster: Union[str, Path, xr.DataArray],
+    hand_raster: Optional[Union[str, Path, xr.DataArray]] = None,
+    hand_out: bool = False,
     tile_shape: Tuple[int, int] = (100, 100),
     max_vv_threshold: float = -15.5,
     max_vh_threshold: float = -23.0,
@@ -241,6 +242,7 @@ def make_water_map(
         vv_raster: Sentinel-1 RTC GeoTIFF, in power scale, with VV polarization
         vh_raster: Sentinel-1 RTC GeoTIFF, in power scale, with VH polarization
         hand_raster: Height Above Nearest Drainage (HAND) GeoTIFF aligned to the RTC rasters
+        hand_out: Whether to output the HAND as a raster
         tile_shape: shape (height, width) in pixels to tile the image to
         max_vv_threshold: Maximum threshold value to use for `vv_raster` in decibels (db)
         max_vh_threshold:  Maximum threshold value to use for `vh_raster` in decibels (db)
@@ -253,7 +255,7 @@ def make_water_map(
     if tile_shape[0] % 2 or tile_shape[1] % 2:
         raise ValueError(f'tile_shape {tile_shape} requires even values.')
 
-    if isinstance(vh_raster, xr.core.dataarray.DataArray):
+    if isinstance(vh_raster, xr.DataArray):
         out_transform = vh_raster.odc.geobox.transform.to_gdal()
         out_crs = vh_raster.odc.crs
         out_epsg = out_crs.to_epsg()
@@ -262,15 +264,39 @@ def make_water_map(
         out_transform = info['geoTransform']
         out_epsg = get_epsg_code(info)
 
-    if hand_raster is None:
-        hand_raster = str(out_raster).replace('.tif', '_HAND.tif')
-        log.info(f'Extracting HAND data to: {hand_raster}')
-        prepare_hand_for_raster(hand_raster, vh_raster)
+    out_path = None
 
-    log.info(f'Determining HAND memberships from {hand_raster}')
-    hand_array = read_as_masked_array(hand_raster)
+    # Warn if user asked to write HAND but also supplied one
+    if hand_out and hand_raster is not None:
+        log.warning("hand_out=True ignored because hand_raster was provided.")
+
+    if isinstance(hand_raster, xr.DataArray):
+        hand_array = hand_raster.to_masked_array()
+        hand_source = "provided xarray"
+
+    elif isinstance(hand_raster, (str, Path)):
+        hand_array = read_as_masked_array(hand_raster)
+        hand_source = f"provided raster: {hand_raster}"
+
+    else:
+        if hand_out:
+            out_path = str(Path(out_raster).with_suffix("")) + "_HAND.tif"
+            log.info(f'Extracting HAND data to: {out_path}')
+
+        hand_xr = prepare_hand_for_raster(
+            source_raster=vh_raster,
+            hand_raster=out_path,
+            return_xarray=True,
+        )
+        hand_array = hand_xr.to_masked_array()
+        hand_source = "computed xarray"
+
+    if out_path is not None:
+        log.info(f'Determining HAND memberships from {hand_source}, which is also written out to {out_path}')
+    else:
+        log.info(f'Determining HAND memberships from {hand_source}')
+
     hand_tiles = tile_array(hand_array, tile_shape=tile_shape, pad_value=np.nan)
-
     hand_candidates = select_hand_tiles(hand_tiles, hand_threshold, hand_fraction)
     log.debug(f'Selected HAND tile candidates {hand_candidates}')
 
@@ -280,7 +306,7 @@ def make_water_map(
     for max_db_threshold, raster, pol in ((max_vh_threshold, vh_raster, 'VH'), (max_vv_threshold, vv_raster, 'VV')):
         log.info(f'Creating initial {pol} water extent map from {raster}')
 
-        if isinstance(vh_raster, xr.core.dataarray.DataArray):
+        if isinstance(vh_raster, xr.DataArray):
             array = raster.to_masked_array()
         else:
             array = read_as_masked_array(raster)


### PR DESCRIPTION
This PR adds the option for the HAND (Height Above Nearest Drainage) image to be input and output as an xarray by allowing the raster computation to occur in memory. It is part of a bigger project to allow HydroSAR and similar software to be compatible with [STAC](https://stacspec.org/en) datasets.

Testing was done over a scene in Australia to ensure that the raster and xarray outputs are numerically identical:

```
from hydrosar.hand.prepare import prepare_hand_for_raster
from asf_tools.raster import read_as_masked_array

vv = ds["VV"].isel(time=1)
vh = ds["VH"].isel(time=1)

hand_xr = prepare_hand_for_raster(
    source_raster=vh,
    hand_raster=None,
    return_xarray=True,
)

hand_path = "test_HAND.tif"
_ = prepare_hand_for_raster(
    source_raster=vh,
    hand_raster=hand_path,
    return_xarray=False,
)

hand_xr_array = hand_xr.to_masked_array()
hand_raster_array = read_as_masked_array(hand_path)
(hand_xr_array == hand_raster_array).all()

[OUT]: True
```

Addresses #51 and #52.